### PR TITLE
Extend integration test script to 'make package'

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,13 @@ To run it execute:
 Eventually, this will launch a server, which exposes [Ledger
 API](https://docs.daml.com/app-dev/ledger-api-introduction/index.html) and
 implements a DAML ledger. It listens on port 6865 by default.
+
+## Testing
+
+The DAML Integration kit describes how to test the conformance of your ledger
+server
+[here](https://docs.daml.com/daml-integration-kit/index.html#integration-kit-testing).
+
+You can test the server in this example as per that approach by running
+
+    make it

--- a/it.sh
+++ b/it.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# NOTE: This file is used by `make it` in a context where the example ledger
+# server has already been built. It is not intended to be used directly.
+
 echo "Detecting current DAML SDK version used in the SBT build..."
 sdkVersion=$(sbt --error 'set showSuccess := false'  printSdkVersion)
 # sdkVersion=$(cat build.sbt| egrep -o "sdkVersion.*=.*\".*\"" | perl -pe 's|sdkVersion.*?=.*?"(.*?)"|\1|')
@@ -11,6 +14,7 @@ echo "Downloading DAML Integration kit Ledger API Test Tool version ${sdkVersion
 curl -L "https://bintray.com/api/v1/content/digitalassetsdk/DigitalAssetSDK/com/daml/ledger/testtool/ledger-api-test-tool_2.12/${sdkVersion}/ledger-api-test-tool_2.12-${sdkVersion}.jar?bt_package=sdk-components" \
      -o ledger-api-test-tool.jar
 
+echo "Extracting the .dar file to load in example server..."
 java -jar ledger-api-test-tool.jar --extract || true # mask incorrect error code of the tool: https://github.com/digital-asset/daml/pull/889
 echo "Launching damlonx-example server..."
 java -jar target/scala-2.12/damlonx-example.jar --port=6865 SemanticTests.dar & serverPid=$!


### PR DESCRIPTION
Before this change the script would terminate with a failure that the
server.jar file was not found, if started from a fresh clone of the
repo.