### PR TITLE
Get IT for damlonx example to run on osx

### DIFF
--- a/it.sh
+++ b/it.sh
@@ -22,12 +22,10 @@ cd ../
 
 echo "Launching damlonx-example server..."
 java -jar target/scala-2.12/damlonx-example.jar --port=6865 target/SemanticTests.dar & serverPid=$!
-printf "Waiting for the server to start"
-while ! timeout 1 bash -c "echo > /dev/tcp/localhost/6865"; do
-    printf "."
-		sleep 1
-done
-echo
+echo "Waiting for the server to start"
+#crude sleep that will work cross platform
+sleep 20
+echo "damlonx-example server started"
 echo "Launching the test tool..."
 java -jar target/ledger-api-test-tool.jar -h localhost -p 6865
 echo "Test tool run is complete."

--- a/it.sh
+++ b/it.sh
@@ -12,12 +12,16 @@ echo "Detected SDK version is $sdkVersion"
 
 echo "Downloading DAML Integration kit Ledger API Test Tool version ${sdkVersion}..."
 curl -L "https://bintray.com/api/v1/content/digitalassetsdk/DigitalAssetSDK/com/daml/ledger/testtool/ledger-api-test-tool_2.12/${sdkVersion}/ledger-api-test-tool_2.12-${sdkVersion}.jar?bt_package=sdk-components" \
-     -o ledger-api-test-tool.jar
+     -o target/ledger-api-test-tool.jar
+
 
 echo "Extracting the .dar file to load in example server..."
-java -jar ledger-api-test-tool.jar --extract || true # mask incorrect error code of the tool: https://github.com/digital-asset/daml/pull/889
+cd target && java -jar ledger-api-test-tool.jar --extract || true # mask incorrect error code of the tool: https://github.com/digital-asset/daml/pull/889
+# back to prior working directory
+cd ../
+
 echo "Launching damlonx-example server..."
-java -jar target/scala-2.12/damlonx-example.jar --port=6865 SemanticTests.dar & serverPid=$!
+java -jar target/scala-2.12/damlonx-example.jar --port=6865 target/SemanticTests.dar & serverPid=$!
 printf "Waiting for the server to start"
 while ! timeout 1 bash -c "echo > /dev/tcp/localhost/6865"; do
     printf "."
@@ -25,7 +29,7 @@ while ! timeout 1 bash -c "echo > /dev/tcp/localhost/6865"; do
 done
 echo
 echo "Launching the test tool..."
-java -jar ledger-api-test-tool.jar -h localhost -p 6865
+java -jar target/ledger-api-test-tool.jar -h localhost -p 6865
 echo "Test tool run is complete."
 echo "Killing the server..."
 kill $serverPid


### PR DESCRIPTION
- Output `ledger-api-test-tool.jar` and `SemanticTests.dar` to target directory so they are not detected as source controlled
- Remove reliance on timeout (not currently available on OSX) for checking whether process has come up, replace with crude sleep for now so it will work cross platform