### PR TITLE
Upgrade to SDK 0.13.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.1.5]
+### Changed
+- Upgrades to version 100.13.39 of DAML SDK
+- (BREAKING CHANGE)
+   `allocateParty` in WriteService now returns `SubmissionResult` rather than `PartyAllocationResult`
+   ResponseMatcher actor no longer needs to wait for response from allocateParty call to match to the request,
+   the submission can now be asyncronous.  The party created response can be read by the calling allocation via the 
+   ledger API service.  If the ledger integration wants to read this response, it can see this in state updates
+   via the read service
+- `allocateParty` now takes a typed `Option[Party]` and a `SubmissionId`
+- Remove handling of party allocation request and associated case classes in `ResponseMatcher`
+- `new` required in StandaloneIndexServer constructor
+- `CommitSubmission` now takes `ByteString` in envelope rather than `DamlSubmission`
+- Use `Envelope.open()` followed by `Envelope.LogEntryMessage()` rather than `KeyValueConsumption.unpackDamlLogEntry`
+- Use `Envelope.enclose()` rather than `KeyValueCommitting.packDamlStateValue`
+    
+
 ## [0.1.4]
 ### Changed
 - Upgrades to version 100.13.38 of DAML SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [0.1.5]
 ### Changed
 - Upgrades to version 100.13.39 of DAML SDK
+- Mandatory implementation of the currentHealth method of the ReportsHealth trait.
 - (BREAKING CHANGE)
    `allocateParty` in WriteService now returns `SubmissionResult` rather than `PartyAllocationResult`
    ResponseMatcher actor no longer needs to wait for response from allocateParty call to match to the request,
    the submission can now be asyncronous.  The party created response can be read by the calling allocation via the 
    ledger API service.  If the ledger integration wants to read this response, it can see this in state updates
    via the read service
-- `allocateParty` now takes a typed `Option[Party]` and a `SubmissionId`
+- `allocateParty` now takes a typed `Option[Party]` and a `SubmissionId`   
 - Remove handling of party allocation request and associated case classes in `ResponseMatcher`
 - `new` required in StandaloneIndexServer constructor
 - `CommitSubmission` now takes `ByteString` in envelope rather than `DamlSubmission`

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ ThisBuild / version := "0.1.3-SNAPSHOT"
 ThisBuild / organization := "com.daml"
 ThisBuild / organizationName := "Digital Asset, LLC"
 
-lazy val sdkVersion = "100.13.38"
+lazy val sdkVersion = "100.13.39"
 lazy val akkaVersion = "2.5.23"
 lazy val jacksonVersion = "2.9.8"
 

--- a/it.sh
+++ b/it.sh
@@ -20,7 +20,7 @@ if [ "$OSNAME" = "Linux" ] ; then
 fi
 
 echo "Extracting the .dar file to load in example server..."
-cd target && java -jar ledger-api-test-tool.jar --extract dummy:11111 || true # mask incorrect error code of the tool: https://github.com/digital-asset/daml/pull/889
+cd target && java -jar ledger-api-test-tool.jar --extract || true # mask incorrect error code of the tool: https://github.com/digital-asset/daml/pull/889
 # back to prior working directory
 cd ../
 

--- a/it.sh
+++ b/it.sh
@@ -31,7 +31,7 @@ echo "Waiting for the server to start"
 sleep 20
 echo "damlonx-example server started"
 echo "Launching the test tool..."
-java -jar target/ledger-api-test-tool.jar localhost:6865 --all-tests --exclude TimeIT,LotsOfPartiesIT --timeout-scale-factor 3.5
+java -jar target/ledger-api-test-tool.jar localhost:6865 --all-tests --exclude TimeIT --timeout-scale-factor 3.5
 echo "Test tool run is complete."
 echo "Killing the server..."
 kill $serverPid

--- a/src/main/scala/com/daml/ledger/damlonxexample/ExampleInMemoryParticipantState.scala
+++ b/src/main/scala/com/daml/ledger/damlonxexample/ExampleInMemoryParticipantState.scala
@@ -191,7 +191,7 @@ class ExampleInMemoryParticipantState(
                     case Right(Envelope.LogEntryMessage(logEntry)) =>
                       logEntry
                     case _ =>
-                      sys.error(s"Envolope did not contain log entry")
+                      sys.error("Envolope did not contain log entry")
                   },
                   participantId
                 )
@@ -358,7 +358,7 @@ class ExampleInMemoryParticipantState(
             val logEntry = Envelope.open(blob) match {
               case Left(err)                                 => sys.error(s"getUpdate: cannot open envelope: $err")
               case Right(Envelope.LogEntryMessage(logEntry)) => logEntry
-              case Right(_)                                  => sys.error(s"getUpdate: Envelope did not contain log entry")
+              case Right(_)                                  => sys.error("getUpdate: Envelope did not contain log entry")
             }
             KeyValueConsumption.logEntryToUpdate(entryId, logEntry)
           }
@@ -516,7 +516,7 @@ class ExampleInMemoryParticipantState(
       case Right(Envelope.LogEntryMessage(logEntry)) =>
         logEntry
       case _ =>
-        sys.error(s"getLogEntry: Envelope did not contain log entry")
+        sys.error("getLogEntry: Envelope did not contain log entry")
     }
   }
 
@@ -527,7 +527,7 @@ class ExampleInMemoryParticipantState(
         blob =>
           Envelope.open(blob) match {
             case Right(Envelope.StateValueMessage(v)) => v
-            case _                                    => sys.error(s"getDamlState: Envelope did not contain a state value")
+            case _                                    => sys.error("getDamlState: Envelope did not contain a state value")
           }
       )
 

--- a/src/main/scala/com/daml/ledger/damlonxexample/ExampleServer.scala
+++ b/src/main/scala/com/daml/ledger/damlonxexample/ExampleServer.scala
@@ -68,7 +68,7 @@ object ExampleServer extends App with EphemeralPostgres {
       loggerFactory,
       SharedMetricRegistries.getOrCreate(s"indexer-${config.participantId}")
     )
-    indexServer <- StandaloneIndexServer(
+    indexServer <- new StandaloneIndexServer(
       config,
       readService,
       writeService,


### PR DESCRIPTION
Upgrade daml-on-x example to latest released SDK 0.13.39 (aka 100.13.39)
Details of changes in CHANGELOG.md

Most impactful changes are move of allocateParty interface to async SubmissionResult response and change in envelope for KV submission and consumption