### PR TITLE
update to SDK 0.13.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.1.6]
+### Changed
+- Upgrades to version 100.13.40 of DAML SDK
+
 ## [0.1.5]
 ### Changed
 - Upgrades to version 100.13.39 of DAML SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [0.1.6]
 ### Changed
 - Upgrades to version 100.13.40 of DAML SDK
+- Remove exclusion of `com.fasterxml.jackson.core` libraries from sandbox and ledger-api-auth as there are no longer problematic clashing versions brought in transitively
 
 ## [0.1.5]
 ### Changed

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ ThisBuild / version := "0.1.3-SNAPSHOT"
 ThisBuild / organization := "com.daml"
 ThisBuild / organizationName := "Digital Asset, LLC"
 
-lazy val sdkVersion = "100.13.39"
+lazy val sdkVersion = "100.13.40"
 lazy val akkaVersion = "2.5.23"
 lazy val jacksonVersion = "2.9.8"
 
@@ -36,8 +36,8 @@ lazy val root = (project in file("."))
       "com.digitalasset" %% "daml-lf-engine" % sdkVersion,
       "com.digitalasset" %% "daml-lf-language" % sdkVersion,
 
-      "com.digitalasset.platform" %% "sandbox" % sdkVersion excludeAll (ExclusionRule("com.fasterxml.jackson.core")),
-      "com.digitalasset.ledger" %% "ledger-api-auth" % sdkVersion excludeAll (ExclusionRule("com.fasterxml.jackson.core")),
+      "com.digitalasset.platform" %% "sandbox" % sdkVersion,
+      "com.digitalasset.ledger" %% "ledger-api-auth" % sdkVersion,
 
       "com.daml.ledger" %% "participant-state" % sdkVersion ,
       "com.daml.ledger" %% "participant-state-kvutils" % sdkVersion,


### PR DESCRIPTION
Upgrade to SDK 0.13.40

Allows us to get rid of exclusion for jackson core now that SDK release includes the resolution to version clash / poisoned jackson pre-release version