### PR TITLE
Upgrade to SDK 0.13.41

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ ThisBuild / version := "0.1.3-SNAPSHOT"
 ThisBuild / organization := "com.daml"
 ThisBuild / organizationName := "Digital Asset, LLC"
 
-lazy val sdkVersion = "100.13.40"
+lazy val sdkVersion = "100.13.41"
 lazy val akkaVersion = "2.5.23"
 lazy val jacksonVersion = "2.9.8"
 

--- a/src/main/scala/com/daml/ledger/damlonxexample/Cli.scala
+++ b/src/main/scala/com/daml/ledger/damlonxexample/Cli.scala
@@ -7,7 +7,6 @@ import java.io.File
 
 import com.digitalasset.daml.lf.data.Ref
 import com.digitalasset.ledger.api.tls.TlsConfiguration
-import com.digitalasset.platform.index.config.Config
 import scopt.Read
 
 object Cli {

--- a/src/main/scala/com/daml/ledger/damlonxexample/Config.scala
+++ b/src/main/scala/com/daml/ledger/damlonxexample/Config.scala
@@ -26,7 +26,7 @@ final case class Config(
 }
 
 object Config {
-  private val DefaultMaxInboundMessageSize = 4 * FileUtils.ONE_MB.toInt
+  val DefaultMaxInboundMessageSize: Int = 4 * FileUtils.ONE_MB.toInt
 
   def default: Config =
     new Config(

--- a/src/main/scala/com/daml/ledger/damlonxexample/Config.scala
+++ b/src/main/scala/com/daml/ledger/damlonxexample/Config.scala
@@ -1,0 +1,43 @@
+package com.daml.ledger.damlonxexample
+
+import java.io.File
+
+import com.daml.ledger.participant.state.v1.ParticipantId
+import com.digitalasset.api.util.TimeProvider
+import com.digitalasset.daml.lf.data.Ref.LedgerString
+import com.digitalasset.ledger.api.tls.TlsConfiguration
+import com.digitalasset.platform.indexer.IndexerStartupMode
+
+final case class Config(
+    port: Int,
+    portFile: Option[File],
+    archiveFiles: List[File],
+    maxInboundMessageSize: Int,
+    timeProvider: TimeProvider, // enables use of non-wall-clock time in tests
+    jdbcUrl: String,
+    tlsConfig: Option[TlsConfiguration],
+    participantId: ParticipantId,
+    extraParticipants: Vector[(ParticipantId, Int, String)],
+    startupMode: IndexerStartupMode
+) {
+  def withTlsConfig(modify: TlsConfiguration => TlsConfiguration): Config =
+    copy(tlsConfig = Some(modify(tlsConfig.getOrElse(TlsConfiguration.Empty))))
+}
+
+object Config {
+  val DefaultMaxInboundMessageSize = 4194304
+
+  def default: Config =
+    new Config(
+      port = 0,
+      portFile = None,
+      archiveFiles = List.empty,
+      maxInboundMessageSize = DefaultMaxInboundMessageSize,
+      timeProvider = TimeProvider.UTC,
+      jdbcUrl = "",
+      tlsConfig = None,
+      participantId = LedgerString.assertFromString("ephemeral-postgres-participant"),
+      extraParticipants = Vector.empty,
+      startupMode = IndexerStartupMode.MigrateAndStart
+    )
+}

--- a/src/main/scala/com/daml/ledger/damlonxexample/Config.scala
+++ b/src/main/scala/com/daml/ledger/damlonxexample/Config.scala
@@ -7,6 +7,7 @@ import com.digitalasset.api.util.TimeProvider
 import com.digitalasset.daml.lf.data.Ref.LedgerString
 import com.digitalasset.ledger.api.tls.TlsConfiguration
 import com.digitalasset.platform.indexer.IndexerStartupMode
+import org.apache.commons.io.FileUtils
 
 final case class Config(
     port: Int,
@@ -25,7 +26,7 @@ final case class Config(
 }
 
 object Config {
-  val DefaultMaxInboundMessageSize = 4194304
+  private val DefaultMaxInboundMessageSize = 4 * FileUtils.ONE_MB.toInt
 
   def default: Config =
     new Config(

--- a/src/main/scala/com/daml/ledger/damlonxexample/ExampleInMemoryParticipantState.scala
+++ b/src/main/scala/com/daml/ledger/damlonxexample/ExampleInMemoryParticipantState.scala
@@ -81,11 +81,6 @@ object ExampleInMemoryParticipantState {
   /** A periodically emitted heartbeat that is committed to the ledger. */
   final case class CommitHeartbeat(recordTime: Timestamp) extends Commit
 
-  final case class AddPackageUploadRequest(
-      submissionId: String,
-      cf: CompletableFuture[UploadPackagesResult]
-  )
-
   final case class AddPotentialResponse(idx: Int)
 
 }
@@ -130,9 +125,6 @@ class ExampleInMemoryParticipantState(
   // Namespace prefix for DAML state.
   private val NS_DAML_STATE = ByteString.copyFromUtf8("DS")
 
-  // For an in-memory ledger, an atomic integer is enough to guarantee uniqueness
-  private val submissionIdSource = new AtomicInteger()
-
   /** Interval for heartbeats. Heartbeats are committed to [[State.commitLog]]
     * and sent as [[Update.Heartbeat]] to [[stateUpdates]] consumers.
     */
@@ -165,57 +157,6 @@ class ExampleInMemoryParticipantState(
     }
     stateRef = newState
   }
-
-  /** Akka actor that matches the requests for party allocation
-    * with asynchronous responses delivered within the log entries.
-    */
-  class ResponseMatcher extends Actor {
-    var packageRequests: Map[String, CompletableFuture[UploadPackagesResult]] = Map.empty
-
-    @SuppressWarnings(Array("org.wartremover.warts.Any"))
-    override def receive: Receive = {
-      case AddPackageUploadRequest(submissionId, cf) =>
-        packageRequests += (submissionId -> cf); ()
-
-      case AddPotentialResponse(idx) =>
-        assert(idx >= 0 && idx < stateRef.commitLog.size)
-
-        stateRef.commitLog(idx) match {
-          case CommitSubmission(entryId, _) =>
-            stateRef.store
-              .get(entryId.getEntryId)
-              .flatMap { blob =>
-                KeyValueConsumption.logEntryToAsyncResponse(
-                  entryId,
-                  Envelope.open(blob) match {
-                    case Right(Envelope.LogEntryMessage(logEntry)) =>
-                      logEntry
-                    case _ =>
-                      sys.error("Envolope did not contain log entry")
-                  },
-                  participantId
-                )
-              }
-              .foreach {
-                case KeyValueConsumption.PackageUploadResponse(submissionId, result) =>
-                  packageRequests
-                    .getOrElse(
-                      submissionId,
-                      sys.error(
-                        s"packageUpload response: $submissionId could not be matched with a request!"
-                      )
-                    )
-                    .complete(result)
-                  packageRequests -= submissionId
-              }
-          case _ => ()
-        }
-    }
-  }
-
-  /** Instance of the [[ResponseMatcher]] to which we send messages used for request-response matching. */
-  private val matcherActorRef =
-    system.actorOf(Props(new ResponseMatcher), s"response-matcher-$ledgerId")
 
   /** Akka actor that receives submissions sequentially and
     * commits them one after another to the state, e.g. appending
@@ -301,7 +242,6 @@ class ExampleInMemoryParticipantState(
 
           // Wake up consumers.
           dispatcher.signalNewHead(stateRef.commitLog.size)
-          matcherActorRef ! AddPotentialResponse(stateRef.commitLog.size - 1)
         }
     }
   }
@@ -472,23 +412,27 @@ class ExampleInMemoryParticipantState(
   private def generateRandomParty(): Ref.Party =
     Ref.Party.assertFromString(s"party-${UUID.randomUUID().toString.take(8)}")
 
-  /** Upload DAML-LF packages to the ledger */
+  /** Upload a collection of DAML-LF packages to the ledger. */
   override def uploadPackages(
+      submissionId: SubmissionId,
       archives: List[Archive],
       sourceDescription: Option[String]
-  ): CompletionStage[UploadPackagesResult] = {
-    val sId = submissionIdSource.getAndIncrement().toString
-    val cf = new CompletableFuture[UploadPackagesResult]
-    matcherActorRef ! AddPackageUploadRequest(sId, cf)
-    commitActorRef ! CommitSubmission(
-      allocateEntryId,
-      Envelope.enclose(
-        KeyValueSubmission
-          .archivesToSubmission(sId, archives, sourceDescription.getOrElse(""), participantId)
+  ): CompletionStage[SubmissionResult] =
+    CompletableFuture.completedFuture({
+      commitActorRef ! CommitSubmission(
+        allocateEntryId,
+        Envelope.enclose(
+          KeyValueSubmission
+            .archivesToSubmission(
+              submissionId,
+              archives,
+              sourceDescription.getOrElse(""),
+              participantId
+            )
+        )
       )
-    )
-    cf
-  }
+      SubmissionResult.Acknowledged
+    })
 
   /** Retrieve the static initial conditions of the ledger, containing
     * the ledger identifier and the initial ledger record time.


### PR DESCRIPTION
Upgrade daml-on-x example to latest SDK 0.13.41

- Async package management means ResponseMatcher is not needed and uploadPackages now returns SubmissionResult
- Config class needs to be defined as part of example as it is no longer available from platform
- StandaloneApiServer rather than StandaloneIndexServer